### PR TITLE
Specify package of interest for coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,3 +71,6 @@ colcon_core.task.test =
 
 [flake8]
 import-order-style = google
+
+[coverage:run]
+source = colcon_ros_bazel


### PR DESCRIPTION
This package's tests don't actually exercise any of the package code. The coverage is currently including the tests in the computation and ignoring the package altogether, so it thinks were' at 93% when we're really at 0%.

This change specifically instructs the coverage tools which package we're interested in.